### PR TITLE
fix(ci): disable uv cache for release-consistency job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           python-version: "3.12"
+          # This job only runs a stdlib-only script (tomllib/re/argparse); it never
+          # invokes uv, so no cache directory is ever created. setup-uv v9 errors in
+          # its post step when asked to save a cache path that does not exist.
+          enable-cache: false
       - run: python scripts/check-release-consistency.py
 
   test:


### PR DESCRIPTION
Fixes CI on `main`, which went red immediately after #5 merged ([run 30917393142](https://github.com/NetDevAutomate/socratic-study-mentor/actions/runs/30917393142)).

## What broke

The `release-consistency` job failed — but not on its actual check:

```
✓ Run python scripts/check-release-consistency.py
X Post Run astral-sh/setup-uv@c771a70e...
```

```
Cache path /home/runner/work/_temp/setup-uv-cache does not exist on disk.
This likely indicates that there are no dependencies to cache.
Consider disabling the cache input if it is not needed.
```

The check passed; the **cleanup** step failed, which still fails the job.

## Why

`release-consistency` runs only `scripts/check-release-consistency.py`, which is stdlib-only (`tomllib`, `re`, `argparse`, `pathlib`). It never invokes `uv` — it installs `setup-uv` purely to get a Python 3.12 interpreter on PATH. So no uv cache directory is ever created, and setup-uv v9 treats "asked to save a cache that does not exist" as an error where v4 did not.

Introduced by the `setup-uv` v4 → v9 bump in #5. Worth noting it **passed on that PR's run and failed on the post-merge run of the same code** — it depends on whether a cache happened to be restored first, so it is timing-dependent rather than deterministic. Not something the PR checks would reliably have caught.

## Fix

`enable-cache: false` on that job only — exactly what the error message recommends. Audited every other job:

| Job | Invokes uv? | Cache |
|---|---|---|
| lint, typecheck, sast, audit, test | `uv sync` | keep |
| build, install-smoke | `uv build` via `build-release.sh` | keep |
| release-consistency | **never** | disabled |

`release-consistency` is the only job in any workflow that pulls in setup-uv without ever running uv, so this is the complete set.

Deliberately not switching it to `actions/setup-python`, which would be the more structurally honest fix: it changes how the job gets its interpreter and risks a `python` vs `python3` difference, for no benefit beyond skipping a ~1s uv download. Noted as a possible tidy-up, not done here.

## Verification

- `python scripts/check-release-consistency.py` passes locally
- `ci.yml` parses, and the rendered step options are `{'python-version': '3.12', 'enable-cache': False}`
- CI on this PR should show all 9 jobs green

The `Failed to save: Unable to reserve cache ... another job may be creating this cache` annotations on `test`/`audit`/`sast` are a pre-existing concurrency warning between parallel jobs sharing one cache key. Warnings, not failures, and present before #5. Left alone.
